### PR TITLE
feat: add healthcheck command and GDEClient stub implementation

### DIFF
--- a/crawler/src/crawler_app/cli.py
+++ b/crawler/src/crawler_app/cli.py
@@ -25,6 +25,14 @@ def _call_build_db() -> int:
         return 1
 
 
+def _call_healthcheck() -> int:
+    try:
+        print("healthcheck (stub): session and GDEClient will be validated later.")
+        return 0
+    except Exception as e:
+        print(f"[healthcheck] error: {e}", file=sys.stderr)
+        return 1
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(prog="crawler_app", description="Crawler CLI")
     sub = parser.add_subparsers(dest="cmd", required=True)
@@ -32,6 +40,7 @@ def main(argv: list[str] | None = None) -> int:
     sub.add_parser("collect", help="Run data collection (HTML + JSON)")
     sub.add_parser("build-db", help="Build SQLite DB from JSON")
     sub.add_parser("run-all", help="Collect then build DB")
+    sub.add_parser("healthcheck", help="Sanity check for session and GDEClient (stub)")
 
     args = parser.parse_args(argv)
     if args.cmd == "collect":
@@ -43,6 +52,8 @@ def main(argv: list[str] | None = None) -> int:
         if rc != 0:
             return rc
         return _call_build_db()
+    if args.cmd == "healthcheck":
+        return _call_healthcheck()
 
     parser.print_help()
     return 2

--- a/crawler/src/crawler_app/clients/__init__.py
+++ b/crawler/src/crawler_app/clients/__init__.py
@@ -1,0 +1,5 @@
+"""Clients package for external APIs (stubs).
+
+This package will host typed clients for GDE JSON endpoints.
+"""
+

--- a/crawler/src/crawler_app/clients/gde_api.py
+++ b/crawler/src/crawler_app/clients/gde_api.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Union
+import requests
+
+
+JSON = Union[Dict[str, Any], List[Dict[str, Any]]]
+
+
+class GDEClient:
+    """Stub client for GDE JSON endpoints.
+
+    This class defines method signatures only; implementation will be added later.
+    """
+
+    def __init__(self, session: requests.Session, base_url: str) -> None:
+        """Initialize the client with a pre-authenticated session and base URL."""
+        raise NotImplementedError("GDEClient.__init__ (stub)")
+
+    def get_courses(self, year: int) -> JSON:
+        """List courses for a given catalog year (JSON)."""
+        raise NotImplementedError("GDEClient.get_courses (stub)")
+
+    def get_offers(self, year: int, course_id: str) -> JSON:
+        """List class offers for a given year and course (JSON)."""
+        raise NotImplementedError("GDEClient.get_offers (stub)")
+
+    def get_curriculum(self, course_id: str, year: int) -> JSON:
+        """Get curriculum structure for a course and year (JSON)."""
+        raise NotImplementedError("GDEClient.get_curriculum (stub)")
+
+    def get_prereqs(self, course_id: str, year: int) -> JSON:
+        """Get prerequisites for a course and year (JSON)."""
+        raise NotImplementedError("GDEClient.get_prereqs (stub)")
+
+    def get_semester_map(self, course_id: str, year: int) -> JSON:
+        """Get recommended semester mapping for a course and year (JSON)."""
+        raise NotImplementedError("GDEClient.get_semester_map (stub)")
+

--- a/docs/gde_endpoints.md
+++ b/docs/gde_endpoints.md
@@ -1,0 +1,70 @@
+# GDE JSON Endpoints (Template)
+
+> Template only. Fill with real values from DevTools (Network) once discovered.
+
+## list_courses
+- URL: `...`
+- Method: `GET`
+- Headers: `...`
+- Params: `year=YYYY`, `q?=...`, `limit?=...`, `offset?=...`
+- Sample response:
+```json
+{
+  "items": [
+    { "id": "34", "code": "MC", "name": "Ciência da Computação" }
+  ],
+  "total": 0
+}
+```
+
+## list_offers
+- URL: `...`
+- Method: `GET`
+- Headers: `...`
+- Params: `year=YYYY`, `courseId=...`, `term?=...`, `teacher?=...`
+- Sample response:
+```json
+{
+  "items": [
+    { "courseCode": "MC202", "term": "2025-1", "classes": [] }
+  ]
+}
+```
+
+## get_curriculum
+- URL: `...`
+- Method: `GET`
+- Headers: `...`
+- Params: `courseId=...`, `year=YYYY`
+- Sample response:
+```json
+{
+  "nodes": [ { "code": "MC102", "name": "Algoritmos" } ],
+  "edges": [ { "from": "MC102", "to": "MC202", "type": "prereq" } ]
+}
+```
+
+## get_prereqs
+- URL: `...`
+- Method: `GET`
+- Headers: `...`
+- Params: `courseId=...`, `year=YYYY`
+- Sample response:
+```json
+{
+  "items": [ { "code": "MC202", "prereqs": ["MC102"] } ]
+}
+```
+
+## get_semester_map
+- URL: `...`
+- Method: `GET`
+- Headers: `...`
+- Params: `courseId=...`, `year=YYYY`
+- Sample response:
+```json
+{
+  "items": [ { "code": "MC202", "recommendedSemester": 3 } ]
+}
+```
+


### PR DESCRIPTION
# 🔀 Template de Pull Request — MC656-2025-s2

## 🧩 Descrição  
Criação dos **stubs iniciais** para o cliente JSON do GDE (`GDEClient`), preparando a migração da coleta via HTML/BeautifulSoup para uma abordagem baseada em **endpoints JSON (JavaScript)**.  

Foram adicionados:  
- Estrutura do pacote `clients/` com `gde_api.py`.  
- Classe `GDEClient` com as 5 assinaturas principais (`get_courses`, `get_offers`, `get_curriculum`, `get_prereqs`, `get_semester_map`).  
- Template de documentação `docs/gde_endpoints.md`.  
- Novo comando `healthcheck` (stub) no `cli.py` para futura validação da sessão e do cliente.  

Essa mudança **não implementa lógica ainda**, apenas define a arquitetura para a próxima etapa (capturar endpoints reais e implementar `get_courses`).

---

## 📂 Escopo das alterações  
- [x] Código  
- [ ] Testes  
- [x] Documentação  

---

## 🧪 Testes realizados  
**Localmente:**  
1. Rodado o comando `python -m crawler_app.cli healthcheck`.  
2. Saída esperada e obtida:  


3. Verificado que os arquivos foram corretamente criados e importáveis:  
- `crawler_app.clients.gde_api` carrega sem erros.  
- O comando `healthcheck` aparece no `--help`.  

---

## ✅ Checklist de revisão (autor)  
- [x] Lint e formatação OK  
- [x] Testes locais passam  
- [x] Critérios de aceite atendidos (stubs criados e PR draft aberto)  
- [x] Documentação atualizada (`docs/gde_endpoints.md` criado)  
- [x] Sem arquivos temporários ou sensíveis  

---

## 👀 Checklist do revisor  
- [ x] Código claro e coeso  
- [ x ] Padrões de nome e arquitetura respeitados  
- [ x ] Cobertura mínima de testes (não aplicável nesta etapa)  
- [ x ] Não quebra contratos públicos  

---

## 🔗 Issues relacionadas  
Resolves #32  
